### PR TITLE
Add method to get table of sim dates for a FRED job

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,10 @@
+[flake8]
+max-line-length = 88
+per-file-ignores =
+    # Standard practice to import modules into init files but not use them
+    __init__.py:F401
+extend-ignore =
+    # Allow line break before binary operator
+    W503
+    # Allow whitespace before colon
+    E203

--- a/docs/quickstart_and_tutorials/index.rst
+++ b/docs/quickstart_and_tutorials/index.rst
@@ -28,7 +28,7 @@ demonstrate usage and features of this package. If FRED is installed at the time
 epx-results is installed, this simulation will be run and may alreay be available.
 If this is not the case, the "simpleflu" model can be run by executing::
 
-   pytyhon ./scripts/generate-test-data.py
+   python ./scripts/generate-test-data.py
 
 
 
@@ -38,3 +38,7 @@ Tutorials
 
 Tutorials on the use of the epx-results package are coming soon.
 
+.. toctree::
+   :maxdepth: 1
+
+   reading_variables

--- a/docs/quickstart_and_tutorials/reading_variables.rst
+++ b/docs/quickstart_and_tutorials/reading_variables.rst
@@ -1,0 +1,70 @@
+.. _reading_variables:
+
+*********************************************
+Reading global varialbes with ``epx-results``
+*********************************************
+
+``epx-results`` provides a Python interface to retrieve FRED global variable
+data as a ``pandas.DataFrame`` object. This is provided by the
+:meth:`epxresults.FREDJob.get_job_variable_table` method. First instantiate a
+:class:`epxresults.FREDJob` object representing your job.
+
+.. code-block: python
+
+    >>> from epxresults import FREDJob
+    >>> job = FREDJob(job_key="simpleflu")
+
+The ``simpleflu`` model contains a global variable called ``Infected``. This can
+be read by calling the :meth:`epxresults.FREDJob.get_job_variable_table` method.
+
+.. code-block: python
+
+    >>> infected_df = job.get_job_variable_table("Infected")
+    >>> infected_df
+        run  sim_day  Infected
+    0     1        0       0.0
+    1     1        1       6.0
+    2     1        2      10.0
+    3     1        3      10.0
+    4     1        4      12.0
+    ..  ...      ...       ...
+    85    3       25    1279.0
+    86    3       26    1412.0
+    87    3       27    1605.0
+    88    3       28    2162.0
+    89    3       29    2635.0
+
+    [90 rows x 3 columns]
+
+For other options, including how to retrieve data at a weekly (rather than
+daily) interval, see documentation for
+:meth:`epxresults.FREDJob.get_job_variable_table`.
+
+Notice that in the output for the example above, time is represented by the
+simulation ``sim_day`` rather than the calendar date that each daily value
+corresponds to. A common pattern is to:
+
+1. Retrieve the simulation dates corresponding to each sim day using the
+   :meth:`epxresults.FREDJob.get_job_date_table` method
+2. Join these into the variable table using :meth:`pandas.DataFrame.merge`.
+3. Calculate the median value of the variable for each simulation date over
+   all model runs
+
+This can be achieved with the following code snippet.
+
+.. code-block: python
+
+    >>> import numpy as np
+    >>> dates_df = job.get_job_date_table()
+    >>> median_infected_s = (
+    ...     infected_df.merge(dates_df, on=['run', 'sim_day'], how='outer')
+    ...     .groupby('sim_date')['Infected'].apply(np.median)
+    ... )
+    >>> median_infected_s.head()
+    sim_date
+    2020-01-01     0.0
+    2020-01-02     6.0
+    2020-01-03    10.0
+    2020-01-04    10.0
+    2020-01-05    12.0
+    Name: Infected, dtype: float64

--- a/epxresults/job.py
+++ b/epxresults/job.py
@@ -1,10 +1,10 @@
 """
 """
-
+from itertools import chain, repeat
 import os
 import re
 import datetime as dt
-from typing import (Dict, List, Optional, Tuple, Union)
+from typing import (Dict, List, Tuple)
 import pandas as pd
 from .utils import (_path_to_job, _path_to_results,
                     return_job_id, return_job_run_ids)
@@ -479,6 +479,18 @@ class FREDJob(object):
             msg = (f"There is no snapshot available for simulation "
                    f"date: {date}.")
             raise KeyError(msg)
+
+    def get_job_date_table(self) -> pd.DataFrame:
+        return (
+            pd.DataFrame.from_records(
+                chain(*[
+                    zip(repeat(i), self.runs[i].sim_days, self.runs[i].sim_dates)
+                    for i in self.runs.keys()
+                ]),
+                columns=["run", "sim_day", "sim_date"]
+            )
+            .assign(sim_date=lambda df: pd.to_datetime(df["sim_date"]))
+        )
 
     def __str__(self) -> str:
         return (

--- a/epxresults/tests/test_job.py
+++ b/epxresults/tests/test_job.py
@@ -1,11 +1,9 @@
 """
 a testing suite for epxresults.job module
 """
-
-import pytest
-import sys
 import os
-import numpy as np
+
+import pandas as pd
 
 from epxresults.job import (
     FREDJob
@@ -68,3 +66,25 @@ def test_5(pkg_test_env):
     PATH_TO_JOB = os.path.join(FRED_RESULTS, 'JOB', str(test_job_id))
     job = FREDJob(PATH_TO_JOB=PATH_TO_JOB)
     assert job.job_key == 'epx-results_simpleflu'
+
+
+def test_job_get_job_date_table():
+    job = FREDJob(job_key='epx-results_simpleflu')
+    dates_df = job.get_job_date_table()
+    assert dates_df.columns.to_list() == ['run', 'sim_day', 'sim_date']
+    assert dates_df['sim_day'].dtype == 'int64'
+    assert dates_df['sim_date'].dtype == '<M8[ns]'
+
+    # Job contains 3 runs from 2020-01-01 to 2020-01-30. That's
+    # 3 * 30 = 90 days in total
+    assert len(dates_df.index) == 90
+    assert dates_df.iloc[0]['sim_date'] == pd.Timestamp('2020-01-01')
+    assert dates_df.iloc[-1]['sim_date'] == pd.Timestamp('2020-01-30')
+
+    # Runs are 1-indexed
+    assert dates_df.iloc[0]['run'] == 1
+    assert dates_df.iloc[-1]['run'] == 3
+
+    # sim days are 0-indexed
+    assert dates_df.iloc[0]['sim_day'] == 0
+    assert dates_df.iloc[-1]['sim_day'] == 29


### PR DESCRIPTION
Implements the `REDJob.get_job_date_table` that @duncandc and I have discussed previously. This allows us to read in the simulation dates corresponding to sim days for all runs in a job.

Also adds Sphinx documentation for how to use this method in conjunction with `FREDJob.get_job_variable_table` to get a time series of median values for a variable across runs. **Note** when following the instructions to build the docs locally I get the following error. We should try to debug this, but for the time being the build of the new docs is untested (though I believe the content to be correct).

```shell
make html
Running Sphinx v4.4.0

Configuration error:
There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "/Users/andrew/Projects/epx-results/.venv/lib/python3.8/site-packages/sphinx/config.py", line 340, in eval_config_file
    exec(code, namespace)
  File "/Users/andrew/Projects/epx-results/docs/conf.py", line 29, in <module>
    from sharedconf import *
ModuleNotFoundError: No module named 'sharedconf'

make: *** [html] Error 2
```