### PR TITLE
Debug local build of epxresults documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,10 +5,23 @@ The documentation for this project is built with [Sphinx](https://www.sphinx-doc
 
 ## building the docs locally
 
+Ensure you have installed the `doc-shared` submodule dependencies
+
+```shell
+git submodule update --init
+```
+
+Install Sphinx requirements (note this is `docs/requirements.txt` as opposed to
+the project root's `requirements.txt`)
+
+```shell
+python -m pip install -r requirements.txt
+```
+
 To build the documentation for epx-results locally, execute the following command:
 
 ```terminal
-make html
+make clean html
 ```
 
 This builds the documentation in `./_build/html`. On a Mac, this can be opened in a browser by:

--- a/docs/quickstart_and_tutorials/getting_started.rst
+++ b/docs/quickstart_and_tutorials/getting_started.rst
@@ -2,9 +2,9 @@
 
 .. _getting_started:
 
-******************************
+********************************
 Getting started with epx-results
-******************************
+********************************
 
 This 10-minute guide gives an overview of the functionality of epx-results
 and each of its sub-packages. You can find links to more detailed information in
@@ -13,7 +13,7 @@ already followed the :ref:`step_by_step_install` section of the documentation to
 and its dependencies set up on your machine.
 
 Importing epx-results
-===================
+=====================
 
 After installing epx-results you can open up a Python terminal and load the entire package by:
 

--- a/docs/quickstart_and_tutorials/reading_variables.rst
+++ b/docs/quickstart_and_tutorials/reading_variables.rst
@@ -1,7 +1,7 @@
 .. _reading_variables:
 
 *********************************************
-Reading global varialbes with ``epx-results``
+Reading global variables with ``epx-results``
 *********************************************
 
 ``epx-results`` provides a Python interface to retrieve FRED global variable
@@ -9,7 +9,7 @@ data as a ``pandas.DataFrame`` object. This is provided by the
 :meth:`epxresults.FREDJob.get_job_variable_table` method. First instantiate a
 :class:`epxresults.FREDJob` object representing your job.
 
-.. code-block: python
+.. code-block:: python
 
     >>> from epxresults import FREDJob
     >>> job = FREDJob(job_key="simpleflu")
@@ -17,7 +17,7 @@ data as a ``pandas.DataFrame`` object. This is provided by the
 The ``simpleflu`` model contains a global variable called ``Infected``. This can
 be read by calling the :meth:`epxresults.FREDJob.get_job_variable_table` method.
 
-.. code-block: python
+.. code-block:: python
 
     >>> infected_df = job.get_job_variable_table("Infected")
     >>> infected_df
@@ -52,7 +52,7 @@ corresponds to. A common pattern is to:
 
 This can be achieved with the following code snippet.
 
-.. code-block: python
+.. code-block:: python
 
     >>> import numpy as np
     >>> dates_df = job.get_job_date_table()

--- a/epxresults/job.py
+++ b/epxresults/job.py
@@ -75,6 +75,8 @@ class FREDJob(object):
         Get a table of global variable values for each run in a job.
     get_job_state_table :
         Get a table of state counts in a condition for each run in a job.
+    get_job_date_table :
+        Mapping of simulation days to simulation dates.
 
     Notes
     -----
@@ -483,6 +485,23 @@ class FREDJob(object):
             raise KeyError(msg)
 
     def get_job_date_table(self) -> pd.DataFrame:
+        """Table mapping sim days to sim dates for all runs in the job.
+
+        Returns
+        -------
+        pd.DataFrame
+            Table with columns ``run``, ``sim_day``, and ``sim_date``.
+            ``sim_date`` is the date represented by ``sim_day`` in
+            the simulation, and ``run`` is the FRED run number. Normally
+            we expect all runs in a job to have the same ``sim_day`` and
+            ``sim_date`` mappings but this is not enforced.
+
+        Examples
+        --------
+        >>> from epxresults import FREDJob
+        >>> job = FREDJob(job_key='simpleflu')
+        >>> df = job.get_job_date_table()
+        """
         return (
             pd.DataFrame.from_records(
                 chain(*[


### PR DESCRIPTION
Adds detail to `docs/README.md` required to build the documentation locally:

- Specify how to install `doc-shared` submodule
- Specify that we need to install docs-specific Python modules using `docs/requirements.txt`

Addresses some warnings that appeared during the build due to section header over/under hangs being too short.

Corrects documentation for the `FREDJob.get_job_date_table` method. Previously the docstring for this method was missing, and the code blocks explaining how to use it in `quickstart_and_tutorials/reading_variables.rst` were malformed.