### PR TITLE
Update RTD config to resolve installation error

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.8"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/conf.py

--- a/README.md
+++ b/README.md
@@ -28,11 +28,32 @@ You may then import epx-results in Python,
 
 ### Local Development
 
-When actively working on this package, it is often convenient to install epx-results in
-an environment in "editable" mode using the `-e` opiton to `pip`:
+To set up a fresh development environment to to work on `epx-results`, we
+recommend using Python's built in `venv` module to create a fresh virtual
+environment. This helps to ensure that if something stops working in the
+development environment, the explanation is inside the `epx-results` repository
+itself, rather than because of some other software installed in a general
+purpose environment.
 
-```terminal
-$user: pip install -e .
+Start by activating a Python environment containing a Python
+executable with the same version you want to use for package development (e.g.
+3.8).
+
+```shell
+$ conda activate epistemix-modeling
+$ which python 
+/opt/miniconda3/envs/epistemix-modeling/bin/python
+$ python -m venv .venv
+$ source .venv/bin/activate
+$ which python
+/Users/username/Projects/epx-results/.venv/bin/python
+```
+
+When actively working on this package, it is often convenient to install
+epx-results in an environment in "editable" mode using the `-e` option to `pip`:
+
+```shell
+pip install -e .
 ```
 
 ### Local Development with Docker

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,13 @@
-## The following requirements were added by pip freeze:
 attrs==21.4.0
-distlib==0.3.4
-filelock==3.4.2
 iniconfig==1.1.1
-numpy==1.22.1
+numpy==1.22.2
 packaging==21.3
-pandas==1.3.5
-platformdirs==2.4.1
+pandas==1.4.1
 pluggy==1.0.0
 py==1.11.0
-pyparsing==3.0.6
-pytest==6.2.5
+pyparsing==3.0.7
+pytest==7.0.1
 python-dateutil==2.8.2
 pytz==2021.3
 six==1.16.0
-toml==0.10.2
-tox==3.24.5
-virtualenv==20.13.0
+tomli==2.0.1


### PR DESCRIPTION
Read the Docs was previosuly configured to use Python 3.7  to run the installation. As this was incompatible with the numpy version specified in requirements.txt, the docs would not build. This PR updates read the docs config to specigy Python 3.8.