### PR TITLE
add delete() method to FREDJob class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- added `delete` method to `FREDJob` class.
+
 ## [0.0.1] - 2022-02-28
 
 ### Added

--- a/epxresults/job.py
+++ b/epxresults/job.py
@@ -119,7 +119,7 @@ class FREDJob(object):
         self.job_id = self._return_job_id(**kwargs)
         self.conditions, self.global_variables = self._parse_vars()
         self._snapshot_map = self._set_snapshot_map()
-        self._results = self._fred_results(**kwargs)
+        self._results_dir = self._fred_results(**kwargs)
 
     def _fred_results(self, **kwargs) -> Path:
         """
@@ -132,54 +132,73 @@ class FREDJob(object):
         """
 
         if 'PATH_TO_JOB' in kwargs.keys():
-            root = Path(self.path_to_job).parent
-            while root != Path('/'):
-                if _is_valid_results_directory(root):
-                    return root
-                else:
-                    root = root.parent
-            return None
+            root = Path(self.path_to_job).parent.parent
+            if _is_valid_results_directory(root):
+                return root
+            else:
+                return None
         else:
             return Path(_path_to_results(**kwargs))
 
-    def delete(self, force=False, verbose=False):
+    def delete(self, verbose: bool = False) -> None:
         """
-        Delete the FRED job
+        Delete the FRED job results on your local file system. Deleting a job
+        is irreversible.
+
+        Parameters
+        ----------
+        verbose : bool
+            print progress and status information
+
+        Notes
+        -----
+        This method both removes the ``self.path_to_job`` directory on a file
+        system and updates the local results ``KEY`` and ``ID`` file if the job
+        is contained within a valid local FRED results directory.
+
+        Raises
+        ------
+        PermissionError
+            If the user has insufficient privileges to remove the FRED job from
+            the local file system.
+        FileNotFoundError
+            If the job has already been removed from the local file system
+            and/or the job is contained within in a non-standard local FRED
+            results directory.
         """
 
-        if force is False:
-            permission_to_delete = None
-            q = (f"Are you sure you want to delete job {self.job_key}?")
-            while permission_to_delete is None:
-                reply = str(input(q + ' (y/n): ')).lower().strip()
-                if reply[0] == 'y':
-                    permission_to_delete = True
-                if reply[0] == 'n':
-                    permission_to_delete = False
-        else:
-            permission_to_delete = True
+        # update job keys in local results directory
+        if self._results_dir is not None:
+            if verbose:
+                print(f"updating local results {self._results_dir}.")
+            local_keys = load_local_job_keys(FRED_RESULTS=self._results_dir)
+            try:
+                del local_keys[self.job_key]
+            except KeyError:
+                if verbose:
+                    msg = (f"no job key matching {self.job_key} found in "
+                           f"the local FRED results {self._results_dir}.")
+            try:
+                _write_local_keys(local_keys, FRED_RESULTS=self._results_dir)
+            except PermissionError:
+                msg = (f"job {self.job_key} could not be deleted from the "
+                       f"local FRED results directory {self._results_dir}. "
+                       f"You may not have permission to modify the directory.")
+                raise PermissionError(msg)
 
-        if permission_to_delete is False:
-            msg = (f"job {self.job_key} could not be deleted.")
-            raise RuntimeError(msg)
-        elif self._results is None:
-            shutil.rmtree(self.path_to_job)
+        # delete job results directory
+        try:
             if verbose:
                 print(f"deleting {self.path_to_job}.")
-        else:
-            local_keys = load_local_job_keys()
-            try:
-                shutil.rmtree(self.path_to_job)
-                del local_keys[self.job_key]
-                _write_local_keys(local_keys, FRED_RESULTS=self._results)
-                if verbose:
-                    print(f"deleting {self.path_to_job}.")
-                    print(f"updating KEY and ID file in {self._results}")
-            except RuntimeError:
-                msg = (f"job {self.job_key} could not be deleted."
-                       f"You may not have permission to modify "
-                       f"{self.path_to_job} or {self._results}")
-                raise RuntimeError(msg)
+            shutil.rmtree(self.path_to_job)
+        except PermissionError:
+            msg = (f"job {self.job_key} could not be deleted."
+                   f"You may not have permission to modify {self.path_to_job}")
+            raise PermissionError(msg)
+        except FileNotFoundError:
+            msg = (f"{self.path_to_job} does not exist. It may have been "
+                   "previously deleted.")
+            raise FileNotFoundError(msg)
 
     @property
     def status(self) -> str:

--- a/epxresults/utils.py
+++ b/epxresults/utils.py
@@ -570,3 +570,28 @@ def _read_list_variable_file(
     df = pd.DatFrame(np.array([float(x) for x in list_data[1:]]))
 
     return df
+
+
+def _is_valid_results_directory(path) -> bool:
+    """
+    Determine if `path` is consistent with being a FRED results directory.
+
+    Parameters
+    ----------
+    path : path-like
+        a path to a potential FRED results directory
+
+    Returns
+    -------
+    is_valid : bool
+        returns True if `path` appears to be a valid FRED results directory
+    """
+
+    if not os.path.isdir(os.path.join(path, 'JOB')):
+        return False
+    elif not os.path.isfile(os.path.join(path, 'ID')):
+        return False
+    elif not os.path.isfile(os.path.join(path, 'KEY')):
+        return False
+    else:
+        return True


### PR DESCRIPTION
This PR adds a new method to the `FREDJob` class, `delete()`.  This method allows users to delete the job results directory and, if appropriate, update the KEY and ID file in the local results directory.

This method can be used as follows:

``` python
>>> job=FREDJob(job_id=13)
>>> job.delete(verbose=True)
```
```
Are you sure you want to delete job 13? (y/n): y
deleting /Users/duncan/.fred/results/JOB/13.
updating KEY and ID file in /Users/duncan/.fred/results
```

The `force` keyword argument allows users to bypass the interaction.