### PR TITLE
Remove redundancy in Lint workflow

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,6 +1,10 @@
 name: Lint
 
-on: [push, pull_request]
+on:
+  pull_request:
+    types: [opened, synchronized, reopened]
+    branches:
+      - main
 
 jobs:
   lint:


### PR DESCRIPTION
Prior to this PR, the "Lint" GitHub Workflow would trigger for every action that included a push or pull request. 
Example:
![image](https://user-images.githubusercontent.com/98825515/174229678-8e8b101f-bd33-42a3-b606-b887d22f18a3.png)


So any pushes to an existing PR would trigger two iterations of `black` format checking to run. This PR has format checking run once only when a PR is opened, updated, or reopened.