### PR TITLE
get_list_table_variable method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - added `delete()` method to `Snapshot` class.
 - added `get_network()` method to `FREDRun` class.
 - added `networkx` as a package dependency.
+- added `get_list_table_variable()` method to `FREDRun` class.
 
 ## Fixed
 

--- a/epxresults/run.py
+++ b/epxresults/run.py
@@ -433,12 +433,9 @@ class FREDRun(object):
                 count += 1
 
         return pd.Series(d, name=variable)
-    
+
     def get_list_table_variable(
-        self,
-        variable: str,
-        sim_day: int = None,
-        long: bool = False
+        self, variable: str, sim_day: int = None, long: bool = False
     ) -> pd.Series:
         """
         Return a list_table variable as a series.
@@ -450,7 +447,7 @@ class FREDRun(object):
 
         sim_day : int
             the simulation day. By default, the last output will be returned.
-            
+
         long : bool
             indicates whether to return a "long" series (float values indexed by keys which may appear more than once). By default, a "wide" series (lists of float values indexed by keys which appear exactly once) will be returned.
 
@@ -478,7 +475,7 @@ class FREDRun(object):
         i = []
         with open(fname, "r") as f:
             lines = f.readlines()
-            
+
         for line in lines[1:]:
             line_list = line.strip().split(",")
             key = line_list[0]

--- a/epxresults/run.py
+++ b/epxresults/run.py
@@ -438,7 +438,7 @@ class FREDRun(object):
         self,
         variable: str,
         sim_day: int = None,
-        long: bool = False,
+        format: str = "long",
     ) -> pd.Series:
         """
         Return a list_table variable as a series.
@@ -451,8 +451,9 @@ class FREDRun(object):
         sim_day : int
             the simulation day. By default, the last output will be returned.
 
-        long : bool
-            indicates whether to return a "long" series (float values indexed by keys which may appear more than once). By default, a "wide" series (lists of float values indexed by keys which appear exactly once) will be returned.
+        format : str, optional
+            the Series format to be returned, either 'wide' (lists of float values indexed by keys which appear exactly once) or 'long' (float values indexed by keys which may appear more than once).
+            By default, long format Series are returned.
 
         Returns
         -------
@@ -483,12 +484,18 @@ class FREDRun(object):
             line_list = line.strip().split(",")
             key = line_list[0]
             values = line_list[1:]
-            if long:
+            if format == "long":
                 i.extend([key for _ in range(len(values))])
                 d.extend(values)
-            else:
+            elif format == "wide":
                 i.append(key)
                 d.append(values)
+            else:
+                msg = (
+                    f"The output format '{format}' for `{variable}` is not a valid option. "
+                    f"The valid options are 'long' and 'wide'."
+                )
+                raise ValueError(msg)
 
         return pd.Series(data=d, index=i, name=variable)
 

--- a/epxresults/run.py
+++ b/epxresults/run.py
@@ -328,11 +328,7 @@ class FREDRun(object):
                 count += 1
         return pd.Series(arr, dtype="float")
 
-    def get_list_variable(
-        self,
-        variable: str,
-        sim_day: int = None,
-    ) -> pd.Series:
+    def get_list_variable(self, variable: str, sim_day: int = None,) -> pd.Series:
         """
         Return an series of values for a global list variable.
 
@@ -387,11 +383,7 @@ class FREDRun(object):
                 count += 1
         return pd.Series(arr, dtype="float")
 
-    def get_table_variable(
-        self,
-        variable: str,
-        sim_day: int = None,
-    ) -> pd.Series:
+    def get_table_variable(self, variable: str, sim_day: int = None,) -> pd.Series:
         """
         Return a table variable as a series.
 
@@ -433,12 +425,9 @@ class FREDRun(object):
                 count += 1
 
         return pd.Series(d, name=variable)
-    
+
     def get_list_table_variable(
-        self,
-        variable: str,
-        sim_day: int = None,
-        long: bool = False
+        self, variable: str, sim_day: int = None, long: bool = False
     ) -> pd.Series:
         """
         Return a list_table variable as a series.
@@ -478,7 +467,7 @@ class FREDRun(object):
         i = []
         with open(fname, "r") as f:
             lines = f.readlines()
-            
+
         for line in lines[1:]:
             line_list = line.strip().split(",")
             key = line_list[0]
@@ -523,10 +512,7 @@ class FREDRun(object):
         return _read_fred_csv(path_to_csv)
 
     def get_network(
-        self,
-        network: str,
-        is_directed: bool = True,
-        sim_day: int = None,
+        self, network: str, is_directed: bool = True, sim_day: int = None,
     ) -> nx.Graph:
         """
         Return a network as a Graph.

--- a/epxresults/run.py
+++ b/epxresults/run.py
@@ -435,7 +435,10 @@ class FREDRun(object):
         return pd.Series(d, name=variable)
 
     def get_list_table_variable(
-        self, variable: str, sim_day: int = None, long: bool = False
+        self,
+        variable: str,
+        sim_day: int = None,
+        long: bool = False,
     ) -> pd.Series:
         """
         Return a list_table variable as a series.

--- a/epxresults/run.py
+++ b/epxresults/run.py
@@ -328,7 +328,11 @@ class FREDRun(object):
                 count += 1
         return pd.Series(arr, dtype="float")
 
-    def get_list_variable(self, variable: str, sim_day: int = None,) -> pd.Series:
+    def get_list_variable(
+        self,
+        variable: str,
+        sim_day: int = None,
+    ) -> pd.Series:
         """
         Return an series of values for a global list variable.
 
@@ -383,7 +387,11 @@ class FREDRun(object):
                 count += 1
         return pd.Series(arr, dtype="float")
 
-    def get_table_variable(self, variable: str, sim_day: int = None,) -> pd.Series:
+    def get_table_variable(
+        self,
+        variable: str,
+        sim_day: int = None,
+    ) -> pd.Series:
         """
         Return a table variable as a series.
 
@@ -425,9 +433,12 @@ class FREDRun(object):
                 count += 1
 
         return pd.Series(d, name=variable)
-
+    
     def get_list_table_variable(
-        self, variable: str, sim_day: int = None, long: bool = False
+        self,
+        variable: str,
+        sim_day: int = None,
+        long: bool = False
     ) -> pd.Series:
         """
         Return a list_table variable as a series.
@@ -467,7 +478,7 @@ class FREDRun(object):
         i = []
         with open(fname, "r") as f:
             lines = f.readlines()
-
+            
         for line in lines[1:]:
             line_list = line.strip().split(",")
             key = line_list[0]
@@ -512,7 +523,10 @@ class FREDRun(object):
         return _read_fred_csv(path_to_csv)
 
     def get_network(
-        self, network: str, is_directed: bool = True, sim_day: int = None,
+        self,
+        network: str,
+        is_directed: bool = True,
+        sim_day: int = None,
     ) -> nx.Graph:
         """
         Return a network as a Graph.


### PR DESCRIPTION
Added a method to the FREDRun class that reads in a list_table written by FRED. The method loads the list_table as a pandas Series in one of two formats (specified by the user): Default is a "wide" series where each key appears exactly once in the index and the value in the Series is a list of numerical values. Second is a "long" series where each value in the Series is a single number and the corresponding key appears in the index once for each value in the associated list.

e.g. wide:
1 [1,2,3]
2 [1, 2]

long:
1 1
1 2
1 3
2 1
2 2